### PR TITLE
Fix race condition when refreshing the UI

### DIFF
--- a/Sources/iOS/UI/LifetimeTracker+DashboardView.swift
+++ b/Sources/iOS/UI/LifetimeTracker+DashboardView.swift
@@ -90,16 +90,18 @@ typealias GroupModel = (color: UIColor, title: String, groupName: String, groupC
     }
 
     @objc public func refreshUI(trackedGroups: [String: LifetimeTracker.EntriesGroup]) {
-        DispatchQueue.main.async {
-            self.window.isHidden = self.visibility.windowIsHidden(hasIssuesToDisplay: self.hasIssuesToDisplay(from: trackedGroups))
+        let entries = Self.entries(from: trackedGroups)
+        let hasIssuesToDisplay = Self.hasIssuesToDisplay(from: trackedGroups)
+        let summary = Self.summary(from: trackedGroups)
 
-            let entries = self.entries(from: trackedGroups)
-            let vm = BarDashboardViewModel(leaksCount: entries.leaksCount, summary: self.summary(from: trackedGroups), sections: entries.groups)
+        DispatchQueue.main.async {
+            self.window.isHidden = self.visibility.windowIsHidden(hasIssuesToDisplay: hasIssuesToDisplay)
+            let vm = BarDashboardViewModel(leaksCount: entries.leaksCount, summary: summary, sections: entries.groups)
             self.lifetimeTrackerView.update(with: vm)
         }
     }
     
-    private func summary(from trackedGroups: [String: LifetimeTracker.EntriesGroup]) -> NSAttributedString {
+    private static func summary(from trackedGroups: [String: LifetimeTracker.EntriesGroup]) -> NSAttributedString {
         let groupNames = trackedGroups.keys.sorted(by: >)
         let leakyGroupSummaries = groupNames.filter { groupName in
             return trackedGroups[groupName]?.lifetimeState == .leaky
@@ -120,7 +122,7 @@ typealias GroupModel = (color: UIColor, title: String, groupName: String, groupC
             ]) + leakyGroupSummaries.attributed()
     }
     
-    private func entries(from trackedGroups: [String: LifetimeTracker.EntriesGroup]) -> (groups: [GroupModel], leaksCount: Int) {
+    private static func entries(from trackedGroups: [String: LifetimeTracker.EntriesGroup]) -> (groups: [GroupModel], leaksCount: Int) {
         var leaksCount = 0
         var sections = [GroupModel]()
         let filteredGroups = trackedGroups.filter { (_, group: LifetimeTracker.EntriesGroup) -> Bool in
@@ -161,7 +163,7 @@ typealias GroupModel = (color: UIColor, title: String, groupName: String, groupC
         return (groups: sections, leaksCount: leaksCount)
     }
     
-    func hasIssuesToDisplay(from trackedGroups: [String: LifetimeTracker.EntriesGroup]) -> Bool {
+    static func hasIssuesToDisplay(from trackedGroups: [String: LifetimeTracker.EntriesGroup]) -> Bool {
         let aDetectedIssue = trackedGroups.keys.first { trackedGroups[$0]?.lifetimeState == .leaky }
         return aDetectedIssue != nil
     }


### PR DESCRIPTION
By generating the entries  before dispatching to the main queue, we are guaranteed the EntriesGroup isn’t getting mutated while we are converting those to GroupModel.